### PR TITLE
ML/MA/BM追加技能への対応

### DIFF
--- a/src/app/plugins/charazip/system/sword-world-2.ts
+++ b/src/app/plugins/charazip/system/sword-world-2.ts
@@ -105,6 +105,7 @@ export class SwordWorld2 implements VampireBloodFactory {
       'アリストクラシー',
       'ドルイド',
       'ジオマンサー',
+      'バトルダンサー',
     ];
     const skillLevelList: number[] = [];
     for (let i = 0; i < skillList.length; i++) {

--- a/src/app/plugins/charazip/system/sword-world-2.ts
+++ b/src/app/plugins/charazip/system/sword-world-2.ts
@@ -104,6 +104,7 @@ export class SwordWorld2 implements VampireBloodFactory {
       'アーティザン',
       'アリストクラシー',
       'ドルイド',
+      'ジオマンサー',
     ];
     const skillLevelList: number[] = [];
     for (let i = 0; i < skillList.length; i++) {
@@ -270,6 +271,12 @@ C({レンジャー}+({知力}/6)) 【魔香水】
 2d+{アリストクラシー}+({精神力}/6) 【印象判定】
 2d+{アリストクラシー}+({知力}/6) 【アリストクラシー観察判定*】危険感知/罠回避 (*要【囁く気配Ⅰ】)
 2d+{アリストクラシー}+({知力}/6) 【アリストクラシー知識判定*】見識/文献 (*要【秘めたる博識Ⅰ】)
+
+`;
+    }
+    if (json.V_GLv25 && json.V_GLv25 !== '0') {
+      cpSearch += `//-----ジオマンサー
+2d+{ジオマンサー}+({知力}/6) 【ジオマンサー観察判定】探索/天候予測
 
 `;
     }
@@ -570,6 +577,20 @@ k40+{バード}+(${bonus}/6)@13 【終律回復40】
 2d+{ミスティック}+({精神力}/6) 【占瞳判定】精神力
 
 `;
+    }
+
+    if (json.V_GLv25 && json.V_GLv25 !== '0') {
+      cpBattle += `//-----相域\n`;
+      for (let i = 0; i < json.GEM_name.length; i++) {
+        const name = json.GEM_name[i];
+        if (!name) {
+          continue;
+        }
+        const koukatime = json.GEM_koukatime[i];
+        const kouka = json.GEM_kouka[i];
+        cpBattle += `【${name}】(${koukatime})${kouka}\n`;
+      }
+      cpBattle += '\n';
     }
 
     palette.setPalette(cpSearch + cpBattle);

--- a/src/app/plugins/charazip/system/sword-world-2.ts
+++ b/src/app/plugins/charazip/system/sword-world-2.ts
@@ -103,6 +103,7 @@ export class SwordWorld2 implements VampireBloodFactory {
       'グリモワール',
       'アーティザン',
       'アリストクラシー',
+      'ドルイド',
     ];
     const skillLevelList: number[] = [];
     for (let i = 0; i < skillList.length; i++) {
@@ -322,13 +323,11 @@ C({レンジャー}+({知力}/6)) 【魔香水】
         cpBattle += `k0+{マギテック}+({知力}/6)${damageMod}+{魔法威力}@${critical} 【威力0】${armsName}
 k10+{マギテック}+({知力}/6)${damageMod}+{魔法威力}@${critical} 【威力10】${armsName}
 k20+{マギテック}+({知力}/6)${damageMod}+{魔法威力}@${critical} 【威力20】${armsName}
-k20+{マギテック}+({知力}/6)${damageMod}+{魔法威力}@${
-          critical - 1
-        } 【威力20】${armsName}/C値-1
+k20+{マギテック}+({知力}/6)${damageMod}+{魔法威力}@${critical - 1
+          } 【威力20】${armsName}/C値-1
 k30+{マギテック}+({知力}/6)${damageMod}+{魔法威力}@${critical} 【威力30】${armsName}
-k30+{マギテック}+({知力}/6)${damageMod}+{魔法威力}@${
-          critical - 1
-        } 【威力30】${armsName}/C値-1
+k30+{マギテック}+({知力}/6)${damageMod}+{魔法威力}@${critical - 1
+          } 【威力30】${armsName}/C値-1
 k40+{マギテック}+({知力}/6)${damageMod}+{魔法威力}@${critical} 【威力40】${armsName}
 k70+{マギテック}+({知力}/6)${damageMod}+{魔法威力}@${critical} 【威力70】${armsName}
 k90+{マギテック}+({知力}/6)${damageMod}+{魔法威力}@${critical} 【威力90】${armsName}
@@ -381,6 +380,12 @@ k${iryoku}+{${hitGinouName}}+({筋力}/6)${damageMod}+{攻撃}@${critical}\${出
         attack: [10, 20, 30, 40, 50, 60, 80, 100],
         heel: [20, 100],
       },
+      {
+        id: 24,
+        alias: '森羅魔法',
+        attack: [10, 20, 30, 50],
+        heel: [],
+      },
     ];
     for (const magic of magicList) {
       const mlv = json[`MLv${magic.id}`];
@@ -406,6 +411,16 @@ k30+{${skillName}}+({知力}/6)${mod}+{魔法威力} 【ゴッド・フィスト
 k40+{${skillName}}+({知力}/6)${mod}+{魔法威力}@11 【ゴッド・フィスト(古代神)】
 `;
       }
+      if (magic.id === 24) {
+        cpBattle += `Dru[0,3,6]+{${skillName}}+({知力}/6)${mod} 【ウルフバイト】
+Dru[4,7,13]+{${skillName}}+({知力}/6)${mod} 【ソーンバッシュ】
+Dru[12,15,18]+{${skillName}}+({知力}/6)${mod} 【コングスマッシュ】
+Dru[13,16,19]+{${skillName}}+({知力}/6)${mod} 【ボアラッシュ】
+Dru[18,21,24]+{${skillName}}+({知力}/6)${mod} 【マルサーヴラプレス】
+Dru[18,21,36]+{${skillName}}+({知力}/6)${mod} 【ルナアタック】
+Dru[24,27,30]+{${skillName}}+({知力}/6)${mod} 【ダブルストンプ】
+`;
+      }
       cpBattle += magic.heel
         .map(
           (iryoku) =>
@@ -414,6 +429,11 @@ k40+{${skillName}}+({知力}/6)${mod}+{魔法威力}@11 【ゴッド・フィス
         .reduce((txt, elm) => txt + elm, '');
       if (magic.id === 21) {
         cpBattle += 'k50@13 【モメント＝レストラーレ】\n';
+      }
+      if (magic.id === 24) {
+        cpBattle += `k10@13 【ナチュラルパワー】
+k30@13 【ナチュラルパワーⅡ】
+`;
       }
       cpBattle += '\n';
     }


### PR DESCRIPTION
- ML/MA/BMで追加された技能への対応を行いました。

## 変更点

### ドルイド技能への対応（ML追加）

- skillListにドルイド技能を追加
- magicListに森羅魔法を追加
- ドルイドの物理魔法用表をチャパレに追加

### ジオマンサー技能への対応（MA追加）

- skillListにジオマンサー技能を追加
- ジオマンサー観察判定パッケージ（探索判定/天候予測判定）をチャパレに追加
- ジオマンサーの相域をチャパレに追加

### バトルダンサー技能への対応（BM追加）

- skillListにバトルダンサー技能を追加

## テスト方法

[テスト用のキャラクターシート](https://charasheet.vampire-blood.net/4801453) について、キャラコマを作成して、以下の点を確認しました。

### ドルイド技能への対応

- ドルイド技能がレベル3として、技能に追加されている
- 森羅魔法行使判定がチャパレに追加されている
- 森羅魔法威力10、森羅魔法威力20、森羅魔法威力30、森羅魔法威力50がチャパレに追加されている
- ウルフバイト、ソーンバッシュ、コングスマッシュ、ボアラッシュ、マルサーヴラプレス、ルナアタック、ダブルストンプで使用する物理魔法用表がチャパレに追加されている
- ナチュラルパワー、ナチュラルパワーⅡで使用する威力表がチャパレに追加されている

### ジオマンサー技能への対応

- ジオマンサー技能がレベル2として、技能に追加されている
- ジオマンサー観察判定がチャパレに追加されている
- 1レベル、2レベルの相域がチャパレに追加されている

### バトルダンサー技能への対応

- バトルダンサー技能がレベル4として、技能に追加されている
- バトルダンサー技能による回避力判定がチャパレに追加されている
- バトルダンサー技能による武器の命中力判定および、その武器の威力計算がチャパレに追加されている